### PR TITLE
Handle first logon case on global recent activity

### DIFF
--- a/src/app/components/activity-event/activity-event.component.html
+++ b/src/app/components/activity-event/activity-event.component.html
@@ -29,6 +29,7 @@
           in <b>{{score.scoreType}}-player</b> mode
         </span>
       </div>
+      <span *ngSwitchCase="127">logged in for the first time</span>
       <span *ngSwitchDefault>Unhandled case: {{_event.eventType}}</span>
     </ng-template>
     <p-gentle>{{getMoment(_event.occurredAt)}}</p-gentle>


### PR DESCRIPTION
Currently the recent activity is filled with messages like this
![image](https://github.com/LittleBigRefresh/refresh-web/assets/34501060/9b3b1203-107f-4e77-856b-4c4d4a419f3e)
