### PR TITLE
Process level-listing routes

### DIFF
--- a/src/app/pages/level-listing/level-listing.component.html
+++ b/src/app/pages/level-listing/level-listing.component.html
@@ -1,4 +1,4 @@
-<page-header class="text-3xl capitalize" title="/api/v3/levels/{{routeName}}">{{routeName}} Levels</page-header>
+<page-header class="text-3xl capitalize" title="/api/v3/levels/{{routeName}}">{{processedRoute}} Levels</page-header>
 
 <div *ngIf="levels">
   <p>There are {{total}} levels in this category.</p>

--- a/src/app/pages/level-listing/level-listing.component.ts
+++ b/src/app/pages/level-listing/level-listing.component.ts
@@ -17,6 +17,8 @@ export class LevelListingComponent implements OnInit {
   levels: Level[] | undefined = undefined;
   routeName!: string
 
+  processedRoute: string = ''
+
   nextPageIndex: number = pageSize + 1;
   total: number = 0;
 
@@ -28,6 +30,7 @@ export class LevelListingComponent implements OnInit {
       if(apiRoute == null) return;
 
       this.routeName = apiRoute;
+      this.processedRoute = this.processRoute(apiRoute);
 
       const pipe = this.apiClient.GetLevelListing(apiRoute, pageSize, 0)
         .pipe(catchError((error: HttpErrorResponse, caught) => {
@@ -47,6 +50,18 @@ export class LevelListingComponent implements OnInit {
     })
   }
 
+  // Instead of just showing the route in PascalCase in the level category, we can process the route and make it look nicer.
+  private processRoute(route: string): string {
+    const routeMap: { [key: string]: string } = {
+      'mostLiked': 'Most Liked',
+      'mostHearted': 'Most Loved',
+      'mostPlayed': 'Most Played',
+      'teamPicks': 'Team Picked',
+      'currentlyPlaying': "Busiest"
+    };
+
+    return routeMap[route] || route; // Default to the original route if it's not found in the mapping.
+  }
   loadNextPage(intersecting: boolean): void {
     if(!intersecting) return;
 


### PR DESCRIPTION
This PR processes the level category route and makes it look nicer on the fronted.

Before:
![image](https://github.com/LittleBigRefresh/refresh-web/assets/17880243/5df25dad-62ba-4859-b873-014d4cc4030c)
After:
![image](https://github.com/LittleBigRefresh/refresh-web/assets/17880243/93573c5f-6428-4323-b102-6a5504f38ec6)
