### PR TITLE
Improve re-uploaded level ui

### DIFF
--- a/src/app/components/level-preview/level-preview.component.html
+++ b/src/app/components/level-preview/level-preview.component.html
@@ -10,12 +10,12 @@
         <fa-icon [icon]="faCircleCheck" class="pr-1"></fa-icon>
       </tooltip>
       <level-statistics [level]="_level" class="text-sm"></level-statistics>
-      <p-gentle>by <user-link [user]="_level.publisher" class="pl-0.5" *ngIf="_level.publisher"
+      <p-gentle>by <tooltip [active]="_level.isReUpload"
+          [text]="'This level is a re-upload, originally published by ' + (_level.originalPublisher === null ? 'an unknown publisher' : _level.originalPublisher) + '.'"><user-link [user]="_level.publisher" class="pl-0.5" *ngIf="_level.publisher"
                                                        [ngClass]="_level.isReUpload ? 'line-through' : ''"></user-link>
-          <tooltip class="pl-0.5"
-              [text]="'This level is a re-upload, originally created by ' + _level.originalPublisher + '.'">
-              <span>{{ _level.originalPublisher }}</span>
-          </tooltip></p-gentle>
+
+              <span class="pl-0.5">{{ _level.originalPublisher }}</span>
+      </tooltip></p-gentle>
       <p-gentle>Created in {{getGameVersion(_level.gameVersion)}} <date [date]="_level.publishDate"></date></p-gentle>
     </div>
   </div>

--- a/src/app/components/tooltip/tooltip.component.html
+++ b/src/app/components/tooltip/tooltip.component.html
@@ -5,7 +5,7 @@
   py-2.5 px-5 bg-backdrop flex items-center justify-center
   transition-opacity duration-300
   not-italic text-foreground font-normal text-base whitespace-nowrap
-  rounded drop-shadow-lg">
+  rounded drop-shadow-lg" *ngIf="_active">
     {{_text}}
   </span>
 </div>

--- a/src/app/components/tooltip/tooltip.component.ts
+++ b/src/app/components/tooltip/tooltip.component.ts
@@ -6,9 +6,15 @@ import {Component, Input} from '@angular/core';
 })
 export class TooltipComponent {
     _text: string = "";
+    _active: boolean = true;
 
     @Input()
     set text(text: string) {
         this._text = text;
+    }
+
+    @Input()
+    set active(active: boolean) {
+        this._active = active;
     }
 }

--- a/src/app/pages/level/level.component.html
+++ b/src/app/pages/level/level.component.html
@@ -11,11 +11,12 @@
 
                 <div class="inline-block text-sm font-normal">
                     <span-gentle>by
+                        <tooltip [active]="level.isReUpload"
+                                            [text]="'This level is a re-upload, originally published by ' + (level.originalPublisher === null ? 'an unknown publisher' : level.originalPublisher) + '.'">
                         <user-link [user]="level.publisher" class="pl-1" *ngIf="level.publisher"
                                    [ngClass]="level.isReUpload ? 'line-through' : ''"></user-link>
-                        <tooltip *ngIf="level.isReUpload" class="pl-1"
-                            [text]="'This level is a re-upload, originally created by ' + level.originalPublisher + '.'">
-                            <span>{{ level.originalPublisher }}</span>
+
+                            <span class="pl-1">{{ level.originalPublisher }}</span>
                         </tooltip>
                     </span-gentle>
                 </div>


### PR DESCRIPTION
Move tooltip to the entire publisher text instead of only the `OriginalPublisher` text

![image](https://github.com/LittleBigRefresh/refresh-web/assets/51852312/2da2101f-eb9a-47bf-ab1a-eaad5173f4ec)