### PR TITLE
Automatic token refreshing, log out page, redirection after logging in/out

### DIFF
--- a/src/app/api/authentication.service.ts
+++ b/src/app/api/authentication.service.ts
@@ -95,7 +95,7 @@ export class AuthenticationService extends ApiImplementation {
         this.http.post<AuthResponse>("/login", body).subscribe({
             error: error => {
                 const apiError: RefreshApiError | undefined = error.error?.error;
-                this.bannerService.error("Sign in failed", apiError == null ? error.message : apiError.message);
+                this.bannerService.error("Failed to sign in", apiError == null ? error.message : apiError.message);
             },
             next: response => {
                 if (response === undefined) {
@@ -131,7 +131,7 @@ export class AuthenticationService extends ApiImplementation {
             next: response => {
                 this.ResetStoredInformation();
 
-                this.bannerService.success("Signed out", "You have been signed out.");
+                this.bannerService.success("Until next time!", "You have been successfully signed out.");
 
                 if (redirectAfterResponse) this.router.navigate(['/']);
             },

--- a/src/app/api/authentication.service.ts
+++ b/src/app/api/authentication.service.ts
@@ -6,6 +6,9 @@ import {ExtendedUser} from "./types/users/extended-user";
 import {AuthRequest} from "./types/auth/auth-request";
 import {AuthResponse} from "./types/auth/auth-response";
 import {BehaviorSubject} from "rxjs";
+import { BannerService } from "../banners/banner.service";
+import { RefreshApiError } from "./refresh-api-error";
+import { AuthRefreshRequest } from "./types/auth/auth-refresh-request";
 
 @Injectable({
     providedIn: 'root'
@@ -13,7 +16,7 @@ import {BehaviorSubject} from "rxjs";
 export class AuthenticationService extends ApiImplementation {
     public user: BehaviorSubject<ExtendedUser | undefined> = new BehaviorSubject<ExtendedUser | undefined>(undefined);
     
-    constructor(http: HttpClient, private tokenStorage: TokenStorageService) {
+    constructor(http: HttpClient, private tokenStorage: TokenStorageService, private bannerService: BannerService) {
         super(http);
 
         const storedToken: string | null = this.tokenStorage.GetStoredGameToken();
@@ -26,12 +29,7 @@ export class AuthenticationService extends ApiImplementation {
         }
         
         if (storedToken) {
-            this.http.get<ExtendedUser>("/users/me").subscribe((data) => {
-                this.user.next(data);
-                this.tokenStorage.SetStoredUser(data);
-
-                console.log(data);
-            });
+            this.GetOwnUser(true);
         }
     }
     
@@ -42,12 +40,43 @@ export class AuthenticationService extends ApiImplementation {
         this.GetOwnUser();
     }
     
-    private GetOwnUser() {
-        this.http.get<ExtendedUser>("/users/me").subscribe((data) => {
-            this.user.next(data);
-            this.tokenStorage.SetStoredUser(data);
+    private GetOwnUser(refreshTokenIfFail: boolean = false) {
+        this.http.get<ExtendedUser>("/users/me").subscribe({
+            error: error => {
+                if (refreshTokenIfFail) 
+                    this.RefreshToken();
+            },
+            next: response => {
+                this.user.next(response);
+                this.tokenStorage.SetStoredUser(response);
 
-            console.log(data);
+                console.log(response);
+            },
+        });
+    }
+
+    private RefreshToken() {
+        const oldRefreshToken: string | null = this.tokenStorage.GetStoredRefreshToken();
+
+        // At this point we know the token exists in the local store
+        const request: AuthRefreshRequest = {
+            tokenData: oldRefreshToken!
+        }
+
+        this.http.post<AuthResponse>("/refreshToken", request).subscribe({
+            error: error => {
+                this.tokenStorage.ClearStoredGameToken();
+                this.tokenStorage.ClearStoredRefreshToken();
+                this.tokenStorage.ClearStoredUser();
+
+                const apiError: RefreshApiError | undefined = error.error?.error;
+                this.bannerService.error("Failed to extend session", apiError == null ? error.message : apiError.message);
+            },
+            next: response => {
+                this.tokenStorage.SetStoredGameToken(response.tokenData);
+                this.tokenStorage.SetStoredRefreshToken(response.refreshTokenData);
+                this.GetOwnUser();
+            },
         });
     }
     
@@ -57,14 +86,20 @@ export class AuthenticationService extends ApiImplementation {
             passwordSha512: password,
         }
         
-        this.http.post<AuthResponse>("/login", body)
-            .subscribe((response) => {
+        this.http.post<AuthResponse>("/login", body).subscribe({
+            error: error => {
+                const apiError: RefreshApiError | undefined = error.error?.error;
+                this.bannerService.error("Login failed", apiError == null ? error.message : apiError.message);
+            },
+            next: response => {
                 if (response === undefined) {
                     console.warn("response was null?", response)
                     return;
                 }
-                
+                    
                 this.HandleAuthResponse(response);
-            });
+                this.bannerService.success("Login successful", "Successfully logged in, have fun!");
+            },
+        });
     }
 }

--- a/src/app/api/types/auth/auth-refresh-request.ts
+++ b/src/app/api/types/auth/auth-refresh-request.ts
@@ -1,0 +1,3 @@
+export interface AuthRefreshRequest {
+    tokenData: string;
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -70,6 +70,11 @@ export const routes: Routes = [
         data: {title: "Sign in"},
     },
     {
+        path: 'logout',
+        loadComponent: () => import('./pages/auth/logout/logout.component').then(x => x.LogoutComponent),
+        data: {title: "Sign Out"},
+    },
+    {
         path: 'contests',
         loadComponent: () => import('./pages/contest-listing/contest-listing.component').then(x => x.ContestListingComponent),
         data: {title: "Contests"},

--- a/src/app/components/ui/form/form.component.ts
+++ b/src/app/components/ui/form/form.component.ts
@@ -14,7 +14,7 @@ import {DividerComponent} from "../divider.component";
     ReactiveFormsModule
 ],
   template: `
-    <form (ngSubmit)="submit.emit(null);" [formGroup]="form">
+    <form (ngSubmit)="submitEvent.emit(null);" [formGroup]="form">
       <ng-content></ng-content>
     
       @if (!compact) {
@@ -29,6 +29,6 @@ import {DividerComponent} from "../divider.component";
 })
 export class FormComponent {
   @Input({required: true}) form: FormGroup = null!;
-  @Output() submit: EventEmitter<null> = new EventEmitter();
+  @Output() submitEvent: EventEmitter<null> = new EventEmitter();
   @Input() compact: boolean = false;
 }

--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -1,6 +1,6 @@
 <app-page-title></app-page-title>
 
-<app-form [form]="form" (submit)="submit()">
+<app-form [form]="form" (submitEvent)="submit()">
     <app-textbox [icon]="faEnvelope" [form]="form" placeholder="sackboy@lbp.me" ctrlName="emailAddress" label="Email Address" type="email"></app-textbox>
     <app-textbox [icon]="faKey" [form]="form" placeholder="•••••••••" ctrlName="password" label="Password" type="password"></app-textbox>
 

--- a/src/app/pages/auth/login/login.component.ts
+++ b/src/app/pages/auth/login/login.component.ts
@@ -32,7 +32,7 @@ export class LoginComponent {
     const password: string = this.form.controls.password.getRawValue();
     
     sha512Async(password).then(passwordSha512 => {
-      this.auth.LogIn(emailAddress, passwordSha512);
+      this.auth.LogIn(emailAddress, passwordSha512, true);
     })
   }
 

--- a/src/app/pages/auth/logout/logout.component.html
+++ b/src/app/pages/auth/logout/logout.component.html
@@ -2,13 +2,13 @@
 
 <div>
     <p>
-        Are you sure you want to log out?
+        Are you sure you want to sign out?
     </p>
 
     <app-divider></app-divider>
 
     <app-button-group>
-        <app-button [icon]="faSignOutAlt" text="Log out" color="bg-red" (click)="this.auth.LogOut(true)"></app-button>
-        <app-button [icon]="faCancel" text="Go back" color="bg-secondary" onClick="window.history.back()"></app-button>
+        <app-button [icon]="faSignOutAlt" text="Sign out" color="bg-red" (click)="this.auth.LogOut(true)"></app-button>
+        <app-button [icon]="faCancel" text="Cancel" color="bg-secondary" onClick="window.history.back()"></app-button>
     </app-button-group>
 </div>

--- a/src/app/pages/auth/logout/logout.component.html
+++ b/src/app/pages/auth/logout/logout.component.html
@@ -8,7 +8,7 @@
     <app-divider></app-divider>
 
     <app-button-group>
-        <app-button text="Log out" color="bg-red" (click)="this.auth.LogOut(true)"></app-button>
-        <app-button text="Go back" color="bg-secondary" onClick="window.history.back()"></app-button>
+        <app-button [icon]="faSignOutAlt" text="Log out" color="bg-red" (click)="this.auth.LogOut(true)"></app-button>
+        <app-button [icon]="faCancel" text="Go back" color="bg-secondary" onClick="window.history.back()"></app-button>
     </app-button-group>
 </div>

--- a/src/app/pages/auth/logout/logout.component.html
+++ b/src/app/pages/auth/logout/logout.component.html
@@ -4,9 +4,11 @@
     <p>
         Are you sure you want to log out?
     </p>
+
     <app-divider></app-divider>
+
     <app-button-group>
-        <app-button text="Log out" (click)="auth.LogOut()"></app-button>
-        <app-button text="Go back" onClick="window.history.back()"></app-button>
+        <app-button text="Log out" color="bg-red" (click)="this.auth.LogOut(true)"></app-button>
+        <app-button text="Go back" color="bg-secondary" onClick="window.history.back()"></app-button>
     </app-button-group>
 </div>

--- a/src/app/pages/auth/logout/logout.component.html
+++ b/src/app/pages/auth/logout/logout.component.html
@@ -1,0 +1,12 @@
+<app-page-title></app-page-title>
+
+<div>
+    <p>
+        Are you sure you want to log out?
+    </p>
+    <app-divider></app-divider>
+    <app-button-group>
+        <app-button text="Log out" (click)="auth.LogOut()"></app-button>
+        <app-button text="Go back" onClick="window.history.back()"></app-button>
+    </app-button-group>
+</div>

--- a/src/app/pages/auth/logout/logout.component.ts
+++ b/src/app/pages/auth/logout/logout.component.ts
@@ -10,12 +10,12 @@ import { faCancel, faSignOutAlt } from "@fortawesome/free-solid-svg-icons";
     selector: 'app-logout',
     standalone: true,
     imports: [
-    PageTitleComponent,
-    ButtonComponent,
-    DividerComponent,
-    ButtonGroupComponent,
-    DividerComponent
-],
+        PageTitleComponent,
+        ButtonComponent,
+        DividerComponent,
+        ButtonGroupComponent,
+        DividerComponent
+    ],
     templateUrl: './logout.component.html'
 })
 

--- a/src/app/pages/auth/logout/logout.component.ts
+++ b/src/app/pages/auth/logout/logout.component.ts
@@ -1,0 +1,26 @@
+import { Component } from "@angular/core";
+import { AuthenticationService } from "../../../api/authentication.service";
+import { PageTitleComponent } from "../../../components/ui/text/page-title.component";
+import { ButtonComponent } from "../../../components/ui/form/button.component";
+import { FormComponent } from "../../../components/ui/form/form.component";
+import { ButtonGroupComponent } from "../../../components/ui/form/button-group.component";
+import { DividerComponent } from "../../../components/ui/divider.component";
+
+@Component({
+    selector: 'app-logout',
+    standalone: true,
+    imports: [
+    PageTitleComponent,
+    ButtonComponent,
+    DividerComponent,
+    ButtonGroupComponent,
+    DividerComponent
+],
+    templateUrl: './logout.component.html'
+})
+
+export class LogoutComponent {
+    constructor(protected auth: AuthenticationService) {
+        
+    }
+}

--- a/src/app/pages/auth/logout/logout.component.ts
+++ b/src/app/pages/auth/logout/logout.component.ts
@@ -4,6 +4,7 @@ import { PageTitleComponent } from "../../../components/ui/text/page-title.compo
 import { ButtonComponent } from "../../../components/ui/form/button.component";
 import { ButtonGroupComponent } from "../../../components/ui/form/button-group.component";
 import { DividerComponent } from "../../../components/ui/divider.component";
+import { faCancel, faSignOutAlt } from "@fortawesome/free-solid-svg-icons";
 
 @Component({
     selector: 'app-logout',
@@ -22,4 +23,7 @@ export class LogoutComponent {
     constructor(protected auth: AuthenticationService) {
         
     }
+
+    protected readonly faSignOutAlt = faSignOutAlt;
+    protected readonly faCancel = faCancel;
 }

--- a/src/app/pages/auth/logout/logout.component.ts
+++ b/src/app/pages/auth/logout/logout.component.ts
@@ -2,7 +2,6 @@ import { Component } from "@angular/core";
 import { AuthenticationService } from "../../../api/authentication.service";
 import { PageTitleComponent } from "../../../components/ui/text/page-title.component";
 import { ButtonComponent } from "../../../components/ui/form/button.component";
-import { FormComponent } from "../../../components/ui/form/form.component";
 import { ButtonGroupComponent } from "../../../components/ui/form/button-group.component";
 import { DividerComponent } from "../../../components/ui/divider.component";
 


### PR DESCRIPTION
Implements a way for the website to try and refresh it's tokens after failing to get your own user once, aswell as a basic log out page (might not be the best UI, but its just a simple log out page) and some fixes regarding duplicate requests. You also get redirected to your user page after successfully logging in, to the start page after logging out and I also added some messaging via the banner service on whether logging in/out was successful or not.
![lel_20250306_202547](https://github.com/user-attachments/assets/dc066f72-8050-430b-b2e2-903cceb7d5b5)
