### PR TITLE
Add ability to toggle in-game visibility of others' modded planets

### DIFF
--- a/src/app/api/types/users/extended-user.ts
+++ b/src/app/api/types/users/extended-user.ts
@@ -11,6 +11,7 @@ export interface ExtendedUser extends User {
 
     unescapeXmlSequences: boolean;
     showModdedContent: boolean;
+    showModdedPlanets: boolean;
     showReuploadedContent: boolean;
     redirectGriefReportsToPhotos: boolean;
 

--- a/src/app/api/types/users/profile-update-request.ts
+++ b/src/app/api/types/users/profile-update-request.ts
@@ -5,6 +5,7 @@ export interface ProfileUpdateRequest {
 
     unescapeXmlSequences: boolean | undefined;
     showModdedContent: boolean | undefined;
+    showModdedPlanets: boolean | undefined;
     showReuploadedContent: boolean | undefined;
     redirectGriefReportsToPhotos: boolean | undefined;
 

--- a/src/app/pages/user-settings/profile/user-profile-settings.component.html
+++ b/src/app/pages/user-settings/profile/user-profile-settings.component.html
@@ -27,6 +27,7 @@
                 <div>
                     <app-checkbox label="Redirect Grief Report Screen&shy;shots to Public Photos" [form]="settingsForm" ctrlName="griefToPhotos" (change)="checkGriefToPhotosChanges()"></app-checkbox>
                     <app-checkbox label="Show modded levels" [form]="settingsForm" ctrlName="showModded" (change)="checkShowModdedChanges()"></app-checkbox>
+                    <app-checkbox label="Show others' modded planets" [form]="settingsForm" ctrlName="showModdedPlanets" (change)="checkShowModdedPlanetsChanges()"></app-checkbox>
                     <app-checkbox label="Show reuploaded levels" [form]="settingsForm" ctrlName="showReuploaded" (change)="checkShowReuploadedChanges()"></app-checkbox>
                     <app-checkbox label="Unescape XML sequences" [form]="settingsForm" ctrlName="unescapeXml" (change)="checkUnescapeXmlChanges()"></app-checkbox>
                 </div>

--- a/src/app/pages/user-settings/profile/user-profile-settings.component.ts
+++ b/src/app/pages/user-settings/profile/user-profile-settings.component.ts
@@ -52,6 +52,7 @@ export class UserProfileSettingsComponent {
         description: new FormControl(),
         unescapeXml: new FormControl(),
         showModded: new FormControl(),
+        showModdedPlanets: new FormControl(),
         showReuploaded: new FormControl(),
         griefToPhotos: new FormControl(),
         levelVisibility: new FormControl(0),
@@ -63,6 +64,7 @@ export class UserProfileSettingsComponent {
     hasDescriptionChanged: boolean = false;
     hasGriefToPhotoChanged: boolean = false;
     hasShowModdedChanged: boolean = false;
+    hasShowModdedPlanetsChanged: boolean = false;
     hasShowReuploadedChanged: boolean = false;
     hasUnescapeXmlChanged: boolean = false;
     hasLevelVisibilityChanged: boolean = false;
@@ -99,6 +101,11 @@ export class UserProfileSettingsComponent {
         this.doesPageHavePendingChanges();
     }
 
+    checkShowModdedPlanetsChanges() {
+        this.hasShowModdedPlanetsChanged = this.settingsForm.controls.showModdedPlanets.getRawValue() != this.ownUser?.showModdedPlanets;
+        this.doesPageHavePendingChanges();
+    }
+
     checkShowReuploadedChanges() {
         this.hasShowReuploadedChanged = this.settingsForm.controls.showReuploaded.getRawValue() != this.ownUser?.showReuploadedContent;
         this.doesPageHavePendingChanges();
@@ -126,6 +133,7 @@ export class UserProfileSettingsComponent {
             this.hasDescriptionChanged
             || this.hasGriefToPhotoChanged
             || this.hasShowModdedChanged
+            || this.hasShowModdedPlanetsChanged
             || this.hasShowReuploadedChanged
             || this.hasShowModdedChanged
             || this.hasUnescapeXmlChanged
@@ -141,6 +149,7 @@ export class UserProfileSettingsComponent {
 
         this.settingsForm.controls.unescapeXml.setValue(user.unescapeXmlSequences);
         this.settingsForm.controls.showModded.setValue(user.showModdedContent);
+        this.settingsForm.controls.showModdedPlanets.setValue(user.showModdedPlanets);
         this.settingsForm.controls.showReuploaded.setValue(user.showReuploadedContent);
         this.settingsForm.controls.griefToPhotos.setValue(user.redirectGriefReportsToPhotos);
 
@@ -156,6 +165,7 @@ export class UserProfileSettingsComponent {
 
             unescapeXmlSequences: this.settingsForm.controls.unescapeXml.getRawValue(),
             showModdedContent: this.settingsForm.controls.showModded.getRawValue(),
+            showModdedPlanets: this.settingsForm.controls.showModdedPlanets.getRawValue(),
             showReuploadedContent: this.settingsForm.controls.showReuploaded.getRawValue(),
             redirectGriefReportsToPhotos: this.settingsForm.controls.griefToPhotos.getRawValue(),
 


### PR DESCRIPTION
This is a follow-up to [the PR where hiding modded planets was added to the server](https://github.com/LittleBigRefresh/Refresh/pull/974).