### PR TITLE
Don't remove token from local store if /refreshToken returns a non-403 error

### DIFF
--- a/src/app/api/authentication.service.ts
+++ b/src/app/api/authentication.service.ts
@@ -81,7 +81,7 @@ export class AuthenticationService extends ApiImplementation {
                     this.bannerService.warn("Session Expired", "Your session has expired, please sign in again.");
                 }
                 else {
-                    this.bannerService.warn("Failed to refresh session", "An unknown error occured (but you are still signed in): " + (apiError === undefined ? error.message : apiError.message));
+                    this.bannerService.warn("Failed to refresh session", "An unknown error occurred (but you are still signed in): " + (apiError === undefined ? error.message : apiError.message));
                 }
             },
             next: response => {


### PR DESCRIPTION
The token now only gets deleted if the server has expired it (`/refreshToken` returns a 403 specifically), and not whenever the endpoint returns any error. This makes testing, aswell as some other scenarios less annoying to deal with.