### PR TITLE
Basic moderation panel page

### DIFF
--- a/src/app/api/client.service.ts
+++ b/src/app/api/client.service.ts
@@ -265,6 +265,10 @@ export class ClientService extends ApiImplementation {
     return this.http.delete<Response>(`/admin/users/uuid/${uuid}/reviews`);
   }
 
+  getAllAnnouncements() {
+    return this.http.get<Announcement[]>(`/announcements`);
+  }
+
   postAnnouncement(announcement: Announcement) {
     return this.http.post<Announcement>(`/admin/announcements`, announcement);
   }

--- a/src/app/api/client.service.ts
+++ b/src/app/api/client.service.ts
@@ -31,7 +31,7 @@ export const defaultPageSize: number = 40;
   providedIn: 'root'
 })
 export class ClientService extends ApiImplementation {
-  private instance: LazySubject<Instance>;
+  private readonly instance: LazySubject<Instance>;
   private readonly levelCategories: LazySubject<ListWithData<LevelCategory>>;
   private readonly userCategories: LazySubject<ListWithData<UserCategory>>;
   private statistics: LazySubject<Statistics>;
@@ -40,28 +40,17 @@ export class ClientService extends ApiImplementation {
 
   constructor(http: HttpClient) {
     super(http);
-
-    this.instance = this.getInstanceInternal();
-    this.statistics = this.getStatisticsInternal();
+    this.instance = new LazySubject<Instance>(() => this.http.get<Instance>("/instance"));
+    this.instance.tryLoad();
 
     this.levelCategories = new LazySubject<ListWithData<LevelCategory>>(() => this.http.get<ListWithData<LevelCategory>>("/levels?includePreviews=true"));
     this.userCategories = new LazySubject<ListWithData<UserCategory>>(() => this.http.get<ListWithData<UserCategory>>("/users?includePreviews=true"));
+
+    this.statistics = this.getStatisticsInternal();
   }
 
-  private getInstanceInternal() {
-    return this.instance = new LazySubject<Instance>(() => this.http.get<Instance>("/instance"));
-  }
-
-  getInstance(ignoreCache: boolean = false) {
-    if (ignoreCache) {
-      this.getInstanceInternal();
-    }
-
+  getInstance() {
     return this.instance.asObservable();
-  }
-
-  updateCachedInstance(instance: Instance) {
-    this.instance = new LazySubject<Instance>(() => new BehaviorSubject<Instance>(instance));
   }
 
   getLevelCategories() {
@@ -74,7 +63,7 @@ export class ClientService extends ApiImplementation {
 
   getStatistics(ignoreCache: boolean = false) {
     if (ignoreCache) {
-      this.getStatisticsInternal();
+      this.statistics = this.getStatisticsInternal();
     }
 
     return this.statistics.asObservable();

--- a/src/app/api/client.service.ts
+++ b/src/app/api/client.service.ts
@@ -23,6 +23,7 @@ import { AdminUserUpdateRequest } from './types/users/admin-user-update-request'
 import { ExtendedUser } from './types/users/extended-user';
 import { PunishUserRequest } from './types/moderation/punish-user-request';
 import { PlanetInfo } from './types/users/planet-info';
+import { Announcement } from './types/announcement';
 
 export const defaultPageSize: number = 40;
 
@@ -30,7 +31,7 @@ export const defaultPageSize: number = 40;
   providedIn: 'root'
 })
 export class ClientService extends ApiImplementation {
-  private readonly instance: LazySubject<Instance>;
+  private instance: LazySubject<Instance>;
   private readonly levelCategories: LazySubject<ListWithData<LevelCategory>>;
   private readonly userCategories: LazySubject<ListWithData<UserCategory>>;
   private statistics: LazySubject<Statistics>;
@@ -39,17 +40,28 @@ export class ClientService extends ApiImplementation {
 
   constructor(http: HttpClient) {
     super(http);
-    this.instance = new LazySubject<Instance>(() => this.http.get<Instance>("/instance"));
-    this.instance.tryLoad();
+
+    this.instance = this.getInstanceInternal();
+    this.statistics = this.getStatisticsInternal();
 
     this.levelCategories = new LazySubject<ListWithData<LevelCategory>>(() => this.http.get<ListWithData<LevelCategory>>("/levels?includePreviews=true"));
     this.userCategories = new LazySubject<ListWithData<UserCategory>>(() => this.http.get<ListWithData<UserCategory>>("/users?includePreviews=true"));
-
-    this.statistics = this.getStatisticsInternal();
   }
 
-  getInstance() {
+  private getInstanceInternal() {
+    return this.instance = new LazySubject<Instance>(() => this.http.get<Instance>("/instance"));
+  }
+
+  getInstance(ignoreCache: boolean = false) {
+    if (ignoreCache) {
+      this.getInstanceInternal();
+    }
+
     return this.instance.asObservable();
+  }
+
+  updateCachedInstance(instance: Instance) {
+    this.instance = new LazySubject<Instance>(() => new BehaviorSubject<Instance>(instance));
   }
 
   getLevelCategories() {
@@ -62,7 +74,7 @@ export class ClientService extends ApiImplementation {
 
   getStatistics(ignoreCache: boolean = false) {
     if (ignoreCache) {
-      this.statistics = this.getStatisticsInternal();
+      this.getStatisticsInternal();
     }
 
     return this.statistics.asObservable();
@@ -262,5 +274,13 @@ export class ClientService extends ApiImplementation {
 
   deleteReviewsByUserByUuid(uuid: string) {
     return this.http.delete<Response>(`/admin/users/uuid/${uuid}/reviews`);
+  }
+
+  postAnnouncement(announcement: Announcement) {
+    return this.http.post<Announcement>(`/admin/announcements`, announcement);
+  }
+
+  deleteAnnouncementByUuid(uuid: string) {
+    return this.http.delete<Response>(`/admin/announcements/${uuid}`);
   }
 }

--- a/src/app/api/types/announcement.ts
+++ b/src/app/api/types/announcement.ts
@@ -2,4 +2,5 @@ export interface Announcement {
     announcementId: string;
     title: string;
     text: string;
+    createdAt: Date | undefined;
 }

--- a/src/app/api/types/instance.ts
+++ b/src/app/api/types/instance.ts
@@ -19,7 +19,6 @@ export interface Instance {
     blockedAssetFlags: AssetConfigFlags;
     blockedAssetFlagsForTrustedUsers: AssetConfigFlags;
 
-    announcements: Announcement[];
     maintenanceModeEnabled: boolean;
     grafanaDashboardUrl: string | null;
     

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -120,6 +120,11 @@ export const routes: Routes = [
         loadComponent: () => import('./pages/instance-info/instance-info.component').then(x => x.InstanceInfoComponent),
         data: {title: "About Us"},
     },
+    {
+        path: 'moderation',
+        loadComponent: () => import('./pages/mod-panel/mod-panel.component').then(x => x.ModPanelComponent),
+        data: {title: "Moderation Panel"},
+    },
     ...appendDebugRoutes(),
     // KEEP THIS ROUTE LAST! It handles pages that do not exist.
     {

--- a/src/app/components/items/announcement.component.ts
+++ b/src/app/components/items/announcement.component.ts
@@ -1,23 +1,60 @@
-import {Component, Input} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {Announcement} from "../../api/types/announcement";
 
 import {FaIconComponent} from "@fortawesome/angular-fontawesome";
-import {faBullhorn} from "@fortawesome/free-solid-svg-icons";
+import {faBullhorn, faTrash} from "@fortawesome/free-solid-svg-icons";
+import { ButtonComponent } from "../ui/form/button.component";
+import { ClientService } from '../../api/client.service';
+import { BannerService } from '../../banners/banner.service';
+import { RefreshApiError } from '../../api/refresh-api-error';
 
 @Component({
     selector: 'app-announcement',
     imports: [
-    FaIconComponent
+    FaIconComponent,
+    ButtonComponent
 ],
     template: `
     <div class="bg-yellow rounded px-5 py-2.5">
-      <fa-icon [icon]="faBullhorn" class="pr-1.5"></fa-icon>
-      <span class="text-xl font-bold">{{data.title}}</span>
-      <p>{{data.text}}</p>
+      <div class="flex flex-row gap-x-2 justify-between">
+        <div>
+          <fa-icon [icon]="faBullhorn" class="pr-1.5"></fa-icon>
+          <span class="text-xl font-bold word-wrap-and-break">{{data.title}}</span>
+        </div>
+
+        @if (showDeleteButton) {
+          <app-button color="bg-red text-[15px]" yPadding="" [icon]="faTrash" color="bg-red" (click)="delete()"></app-button>
+        }
+      </div>
+      
+      <p class="word-wrap-and-break">{{data.text}}</p>
     </div>
   `
 })
 export class AnnouncementComponent {
   @Input({required: true}) data: Announcement = undefined!;
+  @Input() showDeleteButton: boolean = false;
+  @Output() deleted = new EventEmitter;
+
+  constructor(protected client: ClientService, protected banner: BannerService) {
+
+  }
+
+  delete() {
+    if (this.data.announcementId.length == 0) return;
+
+    this.client.deleteAnnouncementByUuid(this.data.announcementId).subscribe({
+      error: error => {
+        const apiError: RefreshApiError | undefined = error.error?.error;
+        this.banner.error("Announcement deletion failed", apiError == null ? error.message : apiError.message);
+      },
+      next: _ => {
+        this.banner.success("Announcement successfully deleted!", "");
+        this.deleted.emit();
+      }
+    });
+  }
+
   protected readonly faBullhorn = faBullhorn;
+  protected readonly faTrash = faTrash;
 }

--- a/src/app/components/items/announcement.component.ts
+++ b/src/app/components/items/announcement.component.ts
@@ -8,13 +8,15 @@ import { ClientService } from '../../api/client.service';
 import { BannerService } from '../../banners/banner.service';
 import { RefreshApiError } from '../../api/refresh-api-error';
 import { ConfirmationDialogComponent } from "../ui/confirmation-dialog.component";
+import { DateComponent } from "../ui/info/date.component";
 
 @Component({
     selector: 'app-announcement',
     imports: [
     FaIconComponent,
     ButtonComponent,
-    ConfirmationDialogComponent
+    ConfirmationDialogComponent,
+    DateComponent
 ],
     template: `
     <div class="bg-yellow rounded px-5 py-2.5">
@@ -30,6 +32,15 @@ import { ConfirmationDialogComponent } from "../ui/confirmation-dialog.component
       </div>
       
       <p class="word-wrap-and-break">{{data.text}}</p>
+
+      @if (data.createdAt != null) {
+        <div class="flex flex-row justify-end">
+          <span class="italic">
+            posted
+            <app-date [date]="data.createdAt"></app-date>
+          </span>
+        </div>
+      }
     </div>
 
     @defer (when showDeletionDialog) { @if (showDeletionDialog) {

--- a/src/app/components/items/announcement.component.ts
+++ b/src/app/components/items/announcement.component.ts
@@ -2,17 +2,19 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {Announcement} from "../../api/types/announcement";
 
 import {FaIconComponent} from "@fortawesome/angular-fontawesome";
-import {faBullhorn, faTrash} from "@fortawesome/free-solid-svg-icons";
+import {faBullhorn, faSignOutAlt, faTrash} from "@fortawesome/free-solid-svg-icons";
 import { ButtonComponent } from "../ui/form/button.component";
 import { ClientService } from '../../api/client.service';
 import { BannerService } from '../../banners/banner.service';
 import { RefreshApiError } from '../../api/refresh-api-error';
+import { ConfirmationDialogComponent } from "../ui/confirmation-dialog.component";
 
 @Component({
     selector: 'app-announcement',
     imports: [
     FaIconComponent,
-    ButtonComponent
+    ButtonComponent,
+    ConfirmationDialogComponent
 ],
     template: `
     <div class="bg-yellow rounded px-5 py-2.5">
@@ -23,12 +25,19 @@ import { RefreshApiError } from '../../api/refresh-api-error';
         </div>
 
         @if (showDeleteButton) {
-          <app-button color="bg-red text-[15px]" yPadding="" [icon]="faTrash" color="bg-red" (click)="delete()"></app-button>
+          <app-button color="bg-red text-[15px]" yPadding="" [icon]="faTrash" color="bg-red" (click)="toggleDeletionDialog(true)"></app-button>
         }
       </div>
       
       <p class="word-wrap-and-break">{{data.text}}</p>
     </div>
+
+    @defer (when showDeletionDialog) { @if (showDeletionDialog) {
+      <app-confirmation-dialog infoText="Do you really want to delete this announcement?" (closeDialog)="toggleDeletionDialog(false)">
+        <app-button text="Cancel" [icon]="faSignOutAlt" color="bg-secondary" (click)="toggleDeletionDialog(false)"></app-button>
+        <app-button text="Delete!" [icon]="faTrash" color="bg-red" (click)="delete()"></app-button>
+      </app-confirmation-dialog>
+    }}
   `
 })
 export class AnnouncementComponent {
@@ -36,12 +45,19 @@ export class AnnouncementComponent {
   @Input() showDeleteButton: boolean = false;
   @Output() deleted = new EventEmitter;
 
+  protected showDeletionDialog: boolean = false;
+
   constructor(protected client: ClientService, protected banner: BannerService) {
 
   }
 
-  delete() {
-    if (this.data.announcementId.length == 0) return;
+  protected toggleDeletionDialog(visibility: boolean) {
+    this.showDeletionDialog = visibility;
+  }
+
+  protected delete() {
+    if (this.data.announcementId.length == 0) return; // fake announcement which doesn't exist on the server
+    this.toggleDeletionDialog(false);
 
     this.client.deleteAnnouncementByUuid(this.data.announcementId).subscribe({
       error: error => {
@@ -57,4 +73,5 @@ export class AnnouncementComponent {
 
   protected readonly faBullhorn = faBullhorn;
   protected readonly faTrash = faTrash;
+  protected readonly faSignOutAlt = faSignOutAlt;
 }

--- a/src/app/components/ui/header/header-me-menu.component.ts
+++ b/src/app/components/ui/header/header-me-menu.component.ts
@@ -8,6 +8,7 @@ import {UserStatisticsComponent} from "../../items/user-statistics.component";
 
 import {DividerComponent} from "../divider.component";
 import {NavItem} from "./navtypes";
+import { UserRoles } from '../../../api/types/users/user-roles';
 
 @Component({
     selector: 'app-header-me-menu',
@@ -37,6 +38,14 @@ import {NavItem} from "./navtypes";
       @for (item of topItems; track item.route) {
         <app-navbar-item [icon]="item.icon" [title]="item.name" [href]="item.route" iconClass="w-4 text-[1.1rem]" labelClass="text-lg"></app-navbar-item>
       }
+
+      @if (isModerator) {
+        <app-divider></app-divider>
+        @for (item of specialItems; track item.route) {
+          <app-navbar-item [icon]="item.icon" [title]="item.name" [href]="item.route" iconClass="w-4 text-[1.1rem]" labelClass="text-lg"></app-navbar-item>
+        }
+      }
+
       <app-divider></app-divider>
       @for (item of bottomItems; track item.route) {
         <app-navbar-item [icon]="item.icon" [title]="item.name" [href]="item.route" iconClass="w-4 text-[1.1rem]" labelClass="text-lg"></app-navbar-item>
@@ -46,6 +55,13 @@ import {NavItem} from "./navtypes";
 })
 export class HeaderMeMenuComponent {
   @Input({required: true}) user: User = undefined!;
+  isModerator: boolean = false;
+
+  ngOnInit() {
+    if (this.user.role >= UserRoles.Moderator) {
+      this.isModerator = true;
+    }
+  }
 
   protected topItems: NavItem[] = [
     {
@@ -62,6 +78,13 @@ export class HeaderMeMenuComponent {
       name: 'Profile Settings',
       icon: 'cog',
       route: '/settings/profile'
+    },
+  ];
+  protected specialItems: NavItem[] = [
+    {
+      name: 'Mod Panel',
+      icon: 'tools',
+      route: '/moderation'
     },
   ];
   protected bottomItems: NavItem[] = [

--- a/src/app/pages/instance-info/instance-info.component.html
+++ b/src/app/pages/instance-info/instance-info.component.html
@@ -1,84 +1,112 @@
 <app-page-title></app-page-title>
-@if(instance != null) {
-    <br><p class="text-3xl">
-        <img [ngSrc]="instance.websiteLogoUrl" class="inline aspect-square object-cover rounded" 
-        alt="Server icon" width="30" height="30"
-        (error)="iconErr($event.target)" loading="lazy">
-        {{ instance.instanceName }}
-    </p>
-    <p class="text-wrap"> {{instance.instanceDescription}}</p>
-    <br>
+<br>
 
-    <h2 class="font-bold text-2xl">Server Information</h2>
-    <p>Software: <span class="italic">{{instance.softwareName}} ({{instance.softwareType}})</span></p>
-    <p>Version: <span class="word-wrap-and-break italic">v{{instance.softwareVersion}}</span></p>
-    <p>License: 
-        <a [href]="instance.softwareLicenseUrl" class="text-link hover:text-link-hover hover:underline">
-            {{ instance.softwareLicenseName }}
-        </a>
-    </p>
-    <p>Source repository: 
-        <a [href]="instance.softwareSourceUrl" class="text-link hover:text-link-hover hover:underline">
-            {{ instance.softwareSourceUrl }}
-        </a>
-    </p>
-    <p>Blocked assets for regular users: <span class="italic">{{ blockedAssetFlags }}</span></p>
-    <p>Blocked assets for trusted users: <span class="italic">{{ blockedAssetFlagsForTrustedUsers }}</span></p>
-    <br>
-
-    <h2 class="font-bold text-2xl">Contact Us</h2>
-    <p>Owner: <span class="italic">{{ instance.contactInfo.adminName }}</span></p>
-
-    @if (instance.contactInfo.adminDiscordUsername != null) {
-        <p>Owner Discord username: <span class="italic">{{ instance.contactInfo.adminDiscordUsername }}</span></p>
-    }
-    @else {
-        <p>No Discord username of the owner</p>
-    }
-    
-    @if (instance.contactInfo.discordServerInvite != null) {
-        <p>Discord server invite:
-            <a [href]="instance.contactInfo.discordServerInvite" class="text-link hover:text-link-hover hover:underline">
-                {{ instance.contactInfo.discordServerInvite }}
+<app-two-pane-layout>
+    <app-container class="w-full">
+        <app-pane-title>
+            <a routerLink='/instance'>
+                Instance
             </a>
-        </p>
-    }
-    @else {
-        <p>No Discord server invite</p>
-    }
+        </app-pane-title>
+        <app-divider></app-divider>
+        <div>
+            @if(instance != null) {
+                <p class="text-3xl">
+                    <img [ngSrc]="instance.websiteLogoUrl" class="inline aspect-square object-cover rounded" 
+                        alt="Server icon" width="30" height="30"
+                        (error)="iconErr($event.target)" loading="lazy">
+                        {{ instance.instanceName }}
+                </p>
+                <p class="text-wrap"> {{instance.instanceDescription}}</p>
+                <br>
+                <h2 class="font-bold text-2xl">Server Information</h2>
+                <p>Software: <span class="italic">{{instance.softwareName}} ({{instance.softwareType}})</span></p>
+                <p>Version: <span class="word-wrap-and-break italic">v{{instance.softwareVersion}}</span></p>
+                <p>License: 
+                    <a [href]="instance.softwareLicenseUrl" class="text-link hover:text-link-hover hover:underline">
+                        {{ instance.softwareLicenseName }}
+                    </a>
+                </p>
+                <p>Source repository: 
+                    <a [href]="instance.softwareSourceUrl" class="text-link hover:text-link-hover hover:underline">
+                        {{ instance.softwareSourceUrl }}
+                    </a>
+                </p>
+                <p>Blocked assets for regular users: <span class="italic">{{ blockedAssetFlags }}</span></p>
+                <p>Blocked assets for trusted users: <span class="italic">{{ blockedAssetFlagsForTrustedUsers }}</span></p>
+                <br>
+                <h2 class="font-bold text-2xl">Contact Us</h2>
+                <p>Owner: <span class="italic">{{ instance.contactInfo.adminName }}</span></p>
 
-    <p>Email address: 
-        <a [href]="'mailto:' + instance.contactInfo.emailAddress" class="text-link hover:text-link-hover hover:underline word-wrap-and-break">
-            {{instance.contactInfo.emailAddress }}
-        </a>
-    </p>
-    <br>
-}
+                @if (instance.contactInfo.adminDiscordUsername != null) {
+                    <p>Owner Discord username: <span class="italic">{{ instance.contactInfo.adminDiscordUsername }}</span></p>
+                }
+                @else {
+                    <p>No Discord username of the owner</p>
+                }
+                
+                @if (instance.contactInfo.discordServerInvite != null) {
+                    <p>Discord server invite:
+                        <a [href]="instance.contactInfo.discordServerInvite" class="text-link hover:text-link-hover hover:underline">
+                            {{ instance.contactInfo.discordServerInvite }}
+                        </a>
+                    </p>
+                }
+                @else {
+                    <p>No Discord server invite</p>
+                }
 
+                <p>Email address: 
+                    <a [href]="'mailto:' + instance.contactInfo.emailAddress" class="text-link hover:text-link-hover hover:underline word-wrap-and-break">
+                        {{instance.contactInfo.emailAddress }}
+                    </a>
+                </p>
+                <br>
+            }
+            @else if (statisticsDownloadFailed) {
+                <p>Failed to download instance metadata.</p>
+            }
+            @else {
+                <p>Downloading instance metadata...</p>
+            }
+        </div>
+    </app-container>
+    <app-container class="w-full">
+        <app-pane-title>
+            <a routerLink='/instance'>
+                Statistics
+            </a>
+        </app-pane-title>
+        <app-divider></app-divider>
+        <div>
+            @if(statistics != null) {
+                <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/users">Registered users: {{statistics.totalUsers}}</a></p>
+                <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/levels">Published levels: {{statistics.totalLevels}}</a></p>
+                <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/levels">Modded levels: {{statistics.moddedLevels}}</a></p>
+                <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/photos">Uploaded photos: {{statistics.totalPhotos}}</a></p>
+                <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/activity">Events occurred: {{statistics.totalEvents}}</a></p>
+                <br>
+                <p>Active users: {{statistics.activeUsers}}</p>
+                <p>People online now: {{statistics.currentIngamePlayersCount}}</p>
+                <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/rooms">Active rooms: {{statistics.currentRoomCount}}</a></p>
+                <br>
+                <p>API requests: {{statistics.requestStatistics.apiRequests}}</p>
+                <p>Game API requests: {{statistics.requestStatistics.gameRequests}}</p>
+            }
+            @else if (statisticsDownloadFailed) {
+                <p>Failed to download instance statistics.</p>
+            }
+            @else {
+                <p>Downloading instance statistics...</p>
+            }
+        </div>
+    </app-container>
+</app-two-pane-layout>
+
+<br>
 <h2 class="font-bold text-2xl">Website</h2>
 <p>Source repository: 
     <a [href]="websiteRepoUrl" class="text-link hover:text-link-hover hover:underline">
         {{ websiteRepoUrl }}
     </a>
 </p>
-<br>
-
-@if(statistics != null) {
-    <h2 class="font-bold text-2xl">Things!</h2>
-    <p><a routerLink="/users">Registered users: {{statistics.totalUsers}}</a></p>
-    <p><a routerLink="/levels">Published levels: {{statistics.totalLevels}}</a></p>
-    <p><a routerLink="/levels">Modded levels: {{statistics.moddedLevels}}</a></p>
-    <p><a routerLink="/photos">Uploaded photos: {{statistics.totalPhotos}}</a></p>
-    <p><a routerLink="/activity">Events occurred: {{statistics.totalEvents}}</a></p>
-    <br>
-
-    <h2 class="font-bold text-2xl">Activity</h2>
-    <p>Active users: {{statistics.activeUsers}}</p>
-    <p>People online now: {{statistics.currentIngamePlayersCount}}</p>
-    <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/rooms">Active rooms: {{statistics.currentRoomCount}}</a></p>
-    <br>
-
-    <h2 class="font-bold text-2xl">Requests ({{statistics.requestStatistics.totalRequests}} in total)</h2>
-    <p>API requests: {{statistics.requestStatistics.apiRequests}}</p>
-    <p>Game API requests: {{statistics.requestStatistics.gameRequests}}</p>
-}

--- a/src/app/pages/instance-info/instance-info.component.ts
+++ b/src/app/pages/instance-info/instance-info.component.ts
@@ -9,19 +9,30 @@ import { NgOptimizedImage } from "@angular/common";
 import { getWebsiteRepoUrl } from '../../helpers/data-fetching';
 import { RouterLink } from "@angular/router";
 import { blockedFlagsAsString } from '../../api/types/asset-config-flags';
+import { TwoPaneLayoutComponent } from "../../components/ui/layouts/two-pane-layout.component";
+import { ContainerComponent } from "../../components/ui/container.component";
+import { PaneTitleComponent } from "../../components/ui/text/pane-title.component";
+import { DividerComponent } from "../../components/ui/divider.component";
 
 @Component({
     selector: 'app-instance-info',
     imports: [
     PageTitleComponent,
     NgOptimizedImage,
-    RouterLink
+    RouterLink,
+    TwoPaneLayoutComponent,
+    ContainerComponent,
+    PaneTitleComponent,
+    DividerComponent
 ],
     templateUrl: './instance-info.component.html'
 })
 export class InstanceInfoComponent {
   protected instance: Instance | undefined;
+  protected instanceDownloadFailed: boolean = false;
+
   protected statistics: Statistics | undefined;
+  protected statisticsDownloadFailed: boolean = false;
 
   protected websiteRepoUrl: String = getWebsiteRepoUrl();
   protected iconError: boolean = false;
@@ -32,6 +43,7 @@ export class InstanceInfoComponent {
   constructor(private client: ClientService, protected banner: BannerService) {
     client.getInstance().subscribe({
       error: error => {
+        this.instanceDownloadFailed = true;
         const apiError: RefreshApiError | undefined = error.error?.error;
         this.banner.error("Failed to retrieve instance data", apiError == null ? error.message : apiError.message);
       },
@@ -44,6 +56,7 @@ export class InstanceInfoComponent {
 
     client.getStatistics(true).subscribe({
       error: error => {
+        this.statisticsDownloadFailed = true;
         const apiError: RefreshApiError | undefined = error.error?.error;
         this.banner.error("Failed to retrieve instance statistics", apiError == null ? error.message : apiError.message);
       },

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -16,7 +16,7 @@
 @if (instance && instance.announcements.length > 0) {
   <div class="my-5 flex flex-col gap-y-2.5">
     @for (a of instance.announcements; track a.announcementId) {
-      <app-announcement [data]="a"></app-announcement>
+      <app-announcement [data]="a" [showDeleteButton]="showAnnouncementDeleteButton"></app-announcement>
     }
   </div>
 }

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -13,10 +13,10 @@
   <p>{{this.instance?.instanceDescription ?? 'Loading...'}}</p>
 </div>
 
-@if (instance && instance.announcements.length > 0) {
+@if (announcements && announcements.length > 0) {
   <div class="my-5 flex flex-col gap-y-2.5">
-    @for (a of instance.announcements; track a.announcementId) {
-      <app-announcement [data]="a" [showDeleteButton]="showAnnouncementDeleteButton"></app-announcement>
+    @for (a of announcements; track a.announcementId) {
+      <app-announcement [data]="a"></app-announcement>
     }
   </div>
 }

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -32,6 +32,8 @@ import {ContestBannerComponent} from "../../components/items/contest-banner.comp
 import { ExtendedUser } from '../../api/types/users/extended-user';
 import { AuthenticationService } from '../../api/authentication.service';
 import { UserRoles } from '../../api/types/users/user-roles';
+import { Announcement } from '../../api/types/announcement';
+import { RefreshApiError } from '../../api/refresh-api-error';
 
 @Component({
     selector: 'app-landing',
@@ -55,6 +57,7 @@ export class LandingComponent implements OnDestroy {
     protected instance: Instance | undefined;
     protected rooms: Room[] | undefined;
     protected activity: ActivityPage | undefined;
+    protected announcements: Announcement[] | undefined;
 
     private activitySubscription: Subscription | undefined;
     private roomsSubscription: Subscription | undefined;
@@ -93,6 +96,17 @@ export class LandingComponent implements OnDestroy {
                 if (user.role >= UserRoles.Moderator) {
                     this.showAnnouncementDeleteButton = true;
                 }
+            }
+        });
+
+        client.getAllAnnouncements().subscribe({
+            error: error => {
+                // don't log, just print to console, as this isn't that important
+                const apiError: RefreshApiError | undefined = error.error?.error;
+                console.warn("Failed to retrieve announcements: " + (apiError == null ? error.message : apiError.message));
+            },
+            next: response => {
+                this.announcements = response;
             }
         });
     }

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -29,6 +29,9 @@ import {ActivityPage} from "../../api/types/activity/activity-page";
 import {EventPageComponent} from "../../components/items/event-page.component";
 import {repeat, Subscription} from "rxjs";
 import {ContestBannerComponent} from "../../components/items/contest-banner.component";
+import { ExtendedUser } from '../../api/types/users/extended-user';
+import { AuthenticationService } from '../../api/authentication.service';
+import { UserRoles } from '../../api/types/users/user-roles';
 
 @Component({
     selector: 'app-landing',
@@ -56,29 +59,42 @@ export class LandingComponent implements OnDestroy {
     private activitySubscription: Subscription | undefined;
     private roomsSubscription: Subscription | undefined;
 
-    constructor(private client: ClientService, @Inject(PLATFORM_ID) platformId: Object, changeDetector: ChangeDetectorRef) {
-      client.getInstance().subscribe(data => this.instance = data);
+    protected ownUser: ExtendedUser | null | undefined;
+    protected showAnnouncementDeleteButton: boolean = false;
 
-      if(isPlatformBrowser(platformId)) {
-          inject(NgZone).runOutsideAngular(() => {
-              this.activitySubscription = this.fetchActivity()
-                  .pipe(repeat({delay: 5000}))
-                  .subscribe(data => {
-                      this.activity = data;
-                      changeDetector.detectChanges();
-                  });
+    constructor(private client: ClientService, @Inject(PLATFORM_ID) platformId: Object, changeDetector: ChangeDetectorRef, protected auth: AuthenticationService) {
+        client.getInstance().subscribe(data => this.instance = data);
 
-              this.roomsSubscription = this.fetchRooms()
-                  .pipe(repeat({delay: 15000}))
-                  .subscribe(data => {
-                      this.rooms = data.data;
-                      changeDetector.detectChanges();
-                  });
-          })
-      }
+        if(isPlatformBrowser(platformId)) {
+            inject(NgZone).runOutsideAngular(() => {
+                this.activitySubscription = this.fetchActivity()
+                    .pipe(repeat({delay: 5000}))
+                    .subscribe(data => {
+                        this.activity = data;
+                        changeDetector.detectChanges();
+                    });
 
-      this.fetchActivity().subscribe(data => this.activity = data);
-      this.fetchRooms().subscribe(data => this.rooms = data.data);
+                this.roomsSubscription = this.fetchRooms()
+                    .pipe(repeat({delay: 15000}))
+                    .subscribe(data => {
+                        this.rooms = data.data;
+                        changeDetector.detectChanges();
+                    });
+            })
+        }
+
+        this.fetchActivity().subscribe(data => this.activity = data);
+        this.fetchRooms().subscribe(data => this.rooms = data.data);
+
+        this.auth.user.subscribe(user => {
+            if (user) {
+                this.ownUser = user;
+
+                if (user.role >= UserRoles.Moderator) {
+                    this.showAnnouncementDeleteButton = true;
+                }
+            }
+        });
     }
 
     ngOnDestroy(): void {

--- a/src/app/pages/mod-panel/mod-panel.component.html
+++ b/src/app/pages/mod-panel/mod-panel.component.html
@@ -68,7 +68,7 @@
 
         <div class="flex flex-row flex-wrap gap-x-2 justify-between pt-4">
           <app-button color="bg-red" [icon]="faTrash" text="Discard" (click)="resetAnnouncementInputs()"></app-button>
-          <app-button color="bg-primary" [icon]="faPaperPlane" text="Publish" (click)="postAnnouncement()" [enabled]="isAnnouncementComplete"></app-button>
+          <app-button color="bg-primary" [icon]="faPaperPlane" text="Publish" (click)="toggleAnnouncementPostDialog(true)" [enabled]="isAnnouncementComplete"></app-button>
         </div>
       </form>
     </div>
@@ -103,10 +103,16 @@
       <iframe [src]="grafanaSafeUrl" class="min-w-full h-[768px]"></iframe>
     </div>
   }
-  
 
   <!-- should always be last section -->
   <app-divider></app-divider>
   <p class="text-xl font-bold pb-2.5">Other Actions</p>
   <p>To manage users, levels, and other data, you can access administrative actions on their respective pages, usually on the page headers.</p>
+
+  @defer (when showAnnouncementPostDialog) { @if (showAnnouncementPostDialog) {
+    <app-confirmation-dialog infoText="Do you really want to post this announcement?" (closeDialog)="toggleAnnouncementPostDialog(false)">
+      <app-button text="Cancel" [icon]="faSignOutAlt" color="bg-secondary" (click)="toggleAnnouncementPostDialog(false)"></app-button>
+      <app-button text="Post!" [icon]="faPaperPlane" color="bg-primary" (click)="postAnnouncement()"></app-button>
+    </app-confirmation-dialog>
+  }}
 }

--- a/src/app/pages/mod-panel/mod-panel.component.html
+++ b/src/app/pages/mod-panel/mod-panel.component.html
@@ -58,10 +58,11 @@
   <app-divider></app-divider>
 
   <p class="text-3xl font-bold pb-2">Announcements</p>
-  <div class="flex flex-row  justify-between gap-10">
-    <div class="w-full">
-      <p class="text-xl font-bold pb-2.5">Create</p>
-      <form class="flex flex-col gap-y-1">
+
+  <div class="grid grid-cols-2 sm:grid-cols-1 md:grid-cols-1 gap-x-6">
+    <div class="w-full pb-4">
+      <p class="text-xl font-bold py-2.5">Create</p>
+      <form class="flex flex-col gap-y-2.5">
         <app-textbox label="Title" placeholder="Hey Everyone!" [icon]="faBullhorn" [form]="announcementForm" ctrlName="title" (change)="checkAnnouncementTitleChanges()"></app-textbox>
         <app-textarea label="Text" placeholder="We will now... yeah, make sure you..." [icon]="faPencil" [form]="announcementForm" ctrlName="text" (change)="checkAnnouncementTextChanges()"></app-textarea>
 
@@ -69,10 +70,10 @@
           <app-button color="bg-red" [icon]="faTrash" text="Discard" (click)="resetAnnouncementInputs()"></app-button>
           <app-button color="bg-primary" [icon]="faPaperPlane" text="Publish" (click)="postAnnouncement()" [enabled]="isAnnouncementComplete"></app-button>
         </div>
-        
       </form>
     </div>
-    <div class="w-full">
+
+    <div class="flex flex-col gap-y-1.5 w-full">
       <p class="text-xl font-bold pb-2.5">Preview</p>
       <app-announcement [data]="previewAnnouncement"></app-announcement>
       <app-divider></app-divider>

--- a/src/app/pages/mod-panel/mod-panel.component.html
+++ b/src/app/pages/mod-panel/mod-panel.component.html
@@ -65,7 +65,11 @@
         <app-textbox label="Title" placeholder="Hey Everyone!" [icon]="faBullhorn" [form]="announcementForm" ctrlName="title" (change)="checkAnnouncementTitleChanges()"></app-textbox>
         <app-textarea label="Text" placeholder="We will now... yeah, make sure you..." [icon]="faPencil" [form]="announcementForm" ctrlName="text" (change)="checkAnnouncementTextChanges()"></app-textarea>
 
-        <app-button [enabled]="isAnnouncementComplete" color="bg-primary" [icon]="faPaperPlane" text="Publish" (click)="postAnnouncement()" class="w-[19rem] text-center my-1.5"></app-button>
+        <div class="flex flex-row flex-wrap gap-x-2 justify-between pt-4">
+          <app-button color="bg-red" [icon]="faTrash" text="Discard" (click)="resetAnnouncementInputs()"></app-button>
+          <app-button color="bg-primary" [icon]="faPaperPlane" text="Publish" (click)="postAnnouncement()" [enabled]="isAnnouncementComplete"></app-button>
+        </div>
+        
       </form>
     </div>
     <div class="w-full">

--- a/src/app/pages/mod-panel/mod-panel.component.html
+++ b/src/app/pages/mod-panel/mod-panel.component.html
@@ -78,18 +78,25 @@
       <app-announcement [data]="previewAnnouncement"></app-announcement>
       <app-divider></app-divider>
       <p class="text-xl font-bold">Live Announcements</p>
-      @if (instance == null && instanceDownloadFailed) {
-        <p>Couldn't get announcements, because we couldn't get instance data.</p>
+      @if (announcements == null) {
+        @if (announcementsDownloadFailed) {
+          <p>Failed to download announcements.</p>
+        }
+        @else {
+          <p>Loading instance data...</p>
+        }
       }
-      @else if (instance == null && !instanceDownloadFailed) {
-        <p>Loading instance data...</p>
-      }
-      @else if (instance!.announcements.length <= 0) {
-        <p>There are no current announcements.</p>
+      @else if (announcements.length <= 0) {
+        @if (announcementsDownloadFailed) {
+          <p>There might be current announcements, reload the page to download them.</p>
+        }
+        @else {
+          <p>There are no current announcements.</p>
+        }
       }
       @else {
         <div class="my-5 flex flex-col gap-y-2.5">
-          @for (announcement of instance!.announcements; track announcement.announcementId) {
+          @for (announcement of announcements; track announcement.announcementId) {
             <app-announcement [data]="announcement" [showDeleteButton]="true" (deleted)="removeAnnouncement(announcement.announcementId)"></app-announcement>
           }
         </div>

--- a/src/app/pages/mod-panel/mod-panel.component.html
+++ b/src/app/pages/mod-panel/mod-panel.component.html
@@ -1,0 +1,107 @@
+@if (ownUser) {
+  <app-page-title></app-page-title>
+  <p>Hi, {{ ownUser.username }}! This is where you manage and view information about {{instance?.instanceName ?? 'this Refresh server'}}.</p>
+  <br>
+
+  <app-two-pane-layout>
+    <app-container class="w-full">
+      <app-pane-title>
+        <a routerLink='/instance'>
+          Instance
+        </a>
+      </app-pane-title>
+      <app-divider></app-divider>
+      <div>
+        @if(instance != null) {
+          <p>Software: <span class="italic">{{instance.softwareName}} ({{instance.softwareType}})</span></p>
+          <p>Version: <span class="word-wrap-and-break italic">v{{instance.softwareVersion}}</span></p>
+          <br>
+          <p>Blocked assets for regular users: <span class="italic">{{ blockedAssetFlags }}</span></p>
+          <p>Blocked assets for trusted users: <span class="italic">{{ blockedAssetFlagsForTrustedUsers }}</span></p>
+        }
+        @else if (instanceDownloadFailed) {
+          <p>Failed to download instance metadata.</p>
+        }
+        @else {
+          <p>Downloading instance metadata...</p>
+        }
+      </div>
+    </app-container>
+    <app-container class="w-full">
+      <app-pane-title>
+        <a routerLink='/instance'>
+          Statistics
+        </a>
+      </app-pane-title>
+      <app-divider></app-divider>
+      <div>
+        @if(statistics != null) {
+          <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/users">Registered users: {{statistics.totalUsers}}</a></p>
+          <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/levels">Published levels: {{statistics.totalLevels}}</a></p>
+          <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/photos">Uploaded photos: {{statistics.totalPhotos}}</a></p>
+          <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/activity">Events occurred: {{statistics.totalEvents}}</a></p>
+          <br>
+          <p>Active users: {{statistics.activeUsers}}</p>
+          <p>People online now: {{statistics.currentIngamePlayersCount}}</p>
+          <p><a class="text-link hover:text-link-hover hover:underline" routerLink="/rooms">Active rooms: {{statistics.currentRoomCount}}</a></p>
+        }
+        @else if (statisticsDownloadFailed) {
+          <p>Failed to download instance statistics.</p>
+        }
+        @else {
+          <p>Downloading instance statistics...</p>
+        }
+      </div>
+    </app-container>
+  </app-two-pane-layout>
+
+  <app-divider></app-divider>
+
+  <p class="text-3xl font-bold pb-2">Announcements</p>
+  <div class="flex flex-row  justify-between gap-10">
+    <div class="w-full">
+      <p class="text-xl font-bold pb-2.5">Create</p>
+      <form class="flex flex-col gap-y-1">
+        <app-textbox label="Title" placeholder="Hey Everyone!" [icon]="faBullhorn" [form]="announcementForm" ctrlName="title" (change)="checkAnnouncementTitleChanges()"></app-textbox>
+        <app-textarea label="Text" placeholder="We will now... yeah, make sure you..." [icon]="faPencil" [form]="announcementForm" ctrlName="text" (change)="checkAnnouncementTextChanges()"></app-textarea>
+
+        <app-button [enabled]="isAnnouncementComplete" color="bg-primary" [icon]="faPaperPlane" text="Publish" (click)="postAnnouncement()" class="w-[19rem] text-center my-1.5"></app-button>
+      </form>
+    </div>
+    <div class="w-full">
+      <p class="text-xl font-bold pb-2.5">Preview</p>
+      <app-announcement [data]="previewAnnouncement"></app-announcement>
+      <app-divider></app-divider>
+      <p class="text-xl font-bold">Live Announcements</p>
+      @if (instance == null && instanceDownloadFailed) {
+        <p>Couldn't get announcements, because we couldn't get instance data.</p>
+      }
+      @else if (instance == null && !instanceDownloadFailed) {
+        <p>Loading instance data...</p>
+      }
+      @else if (instance!.announcements.length <= 0) {
+        <p>There are no current announcements.</p>
+      }
+      @else {
+        <div class="my-5 flex flex-col gap-y-2.5">
+          @for (announcement of instance!.announcements; track announcement.announcementId) {
+            <app-announcement [data]="announcement" [showDeleteButton]="true" (deleted)="removeAnnouncement(announcement.announcementId)"></app-announcement>
+          }
+        </div>
+      }
+    </div>
+  </div>
+
+  @if (this.grafanaSafeUrl != null) {
+    <div>
+      <app-divider></app-divider>
+      <iframe [src]="grafanaSafeUrl" class="min-w-full h-[768px]"></iframe>
+    </div>
+  }
+  
+
+  <!-- should always be last section -->
+  <app-divider></app-divider>
+  <p class="text-xl font-bold pb-2.5">Other Actions</p>
+  <p>To manage users, levels, and other data, you can access administrative actions on their respective pages, usually on the page headers.</p>
+}

--- a/src/app/pages/mod-panel/mod-panel.component.ts
+++ b/src/app/pages/mod-panel/mod-panel.component.ts
@@ -1,0 +1,172 @@
+import { Component } from '@angular/core';
+import {ClientService} from "../../api/client.service";
+import { PageTitleComponent } from "../../components/ui/text/page-title.component";
+import { ExtendedUser } from '../../api/types/users/extended-user';
+import { AuthenticationService } from '../../api/authentication.service';
+import { UserRoles } from '../../api/types/users/user-roles';
+import { BannerService } from '../../banners/banner.service';
+import { Instance } from '../../api/types/instance';
+import { Statistics } from '../../api/types/statistics';
+import { RefreshApiError } from '../../api/refresh-api-error';
+import { blockedFlagsAsString } from '../../api/types/asset-config-flags';
+import { DividerComponent } from "../../components/ui/divider.component";
+import { FormControl, FormGroup } from '@angular/forms';
+import { AnnouncementComponent } from "../../components/items/announcement.component";
+import { Announcement } from '../../api/types/announcement';
+import { faBullhorn, faPaperPlane, faPencil } from '@fortawesome/free-solid-svg-icons';
+import { TextboxComponent } from "../../components/ui/form/textbox.component";
+import { TextAreaComponent } from "../../components/ui/form/textarea.component";
+import { ButtonComponent } from "../../components/ui/form/button.component";
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { RouterLink } from "@angular/router";
+import { TwoPaneLayoutComponent } from "../../components/ui/layouts/two-pane-layout.component";
+import { ContainerComponent } from "../../components/ui/container.component";
+import { PaneTitleComponent } from "../../components/ui/text/pane-title.component";
+
+@Component({
+    selector: 'app-mod-panel',
+    imports: [
+    PageTitleComponent,
+    DividerComponent,
+    AnnouncementComponent,
+    TextboxComponent,
+    TextAreaComponent,
+    ButtonComponent,
+    RouterLink,
+    TwoPaneLayoutComponent,
+    ContainerComponent,
+    PaneTitleComponent
+],
+    templateUrl: './mod-panel.component.html'
+})
+export class ModPanelComponent {
+  protected ownUser: ExtendedUser | null | undefined;
+
+  protected instance: Instance | undefined;
+  protected instanceDownloadFailed: boolean = false;
+  protected blockedAssetFlags: String = "None";
+  protected blockedAssetFlagsForTrustedUsers: String = "None";
+
+  protected statistics: Statistics | undefined;
+  protected statisticsDownloadFailed: boolean = false;
+
+  protected previewAnnouncement: Announcement = {
+    announcementId: "",
+    title: "",
+    text: "",
+  };
+  protected announcementForm = new FormGroup({
+    title: new FormControl(),
+    text: new FormControl(),
+  });
+  protected isAnnouncementComplete: boolean = false;
+
+  protected grafanaSafeUrl: SafeUrl | undefined;
+
+  constructor(private auth: AuthenticationService, private client: ClientService, protected banner: BannerService, private sanitizer: DomSanitizer) {
+    this.auth.user.subscribe(user => {
+      if (user) {
+        if (user.role < UserRoles.Moderator) {
+          this.banner.error("You are not a moderator", "Get out!");
+        }
+        else {
+          this.ownUser = user;
+
+          client.getInstance().subscribe({
+            error: error => {
+              this.instanceDownloadFailed = true;
+              const apiError: RefreshApiError | undefined = error.error?.error;
+              this.banner.error("Failed to retrieve instance data", apiError == null ? error.message : apiError.message);
+            },
+            next: response => {
+              this.instance = response;
+              this.blockedAssetFlags = blockedFlagsAsString(response.blockedAssetFlags);
+              this.blockedAssetFlagsForTrustedUsers = blockedFlagsAsString(response.blockedAssetFlagsForTrustedUsers);
+
+              // initialize sanitized URL
+              let originalUrl = this.instance?.grafanaDashboardUrl;
+              if (originalUrl == null || originalUrl.length <= 0) {
+                originalUrl = "";
+              }
+
+              this.grafanaSafeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(originalUrl);
+              console.log("safe grafana url: " + this.grafanaSafeUrl);
+            }
+          });
+      
+          client.getStatistics().subscribe({
+            error: error => {
+              this.statisticsDownloadFailed = true;
+              const apiError: RefreshApiError | undefined = error.error?.error;
+              this.banner.error("Failed to retrieve instance statistics", apiError == null ? error.message : apiError.message);
+            },
+            next: response => {
+              this.statistics = response;
+            }
+          });
+        }
+      }
+    });
+  }
+
+  protected checkAnnouncementTitleChanges() {
+    let currentTitle: string = this.announcementForm.controls.title.getRawValue();
+    this.previewAnnouncement.title = currentTitle;
+    this.checkAnnouncementCompleteness();
+  }
+
+  protected checkAnnouncementTextChanges() {
+    let currentText: string = this.announcementForm.controls.text.getRawValue();
+    this.previewAnnouncement.text = currentText;
+    this.checkAnnouncementCompleteness();
+  }
+
+  protected checkAnnouncementCompleteness() {
+    this.isAnnouncementComplete = this.previewAnnouncement.title.length > 0 && this.previewAnnouncement.text.length > 0;
+  }
+
+  protected resetAnnouncementInputs() {
+    this.isAnnouncementComplete = false;
+    this.announcementForm.controls.title.setValue("");
+    this.announcementForm.controls.text.setValue("");
+
+    this.previewAnnouncement = {
+      announcementId: "",
+      title: "",
+      text: "",
+    };
+  }
+
+  protected postAnnouncement() {
+    if (this.instance == null || !this.isAnnouncementComplete) return;
+    
+    this.client.postAnnouncement(this.previewAnnouncement).subscribe({
+      error: error => {
+        const apiError: RefreshApiError | undefined = error.error?.error;
+        this.banner.error("Failed to post the announcement", apiError == null ? error.message : apiError.message);
+      },
+      next: response => {
+        this.resetAnnouncementInputs();
+
+        // currently the server doesn't sort the announcements, so this is fine
+        this.instance!.announcements.push(response);
+      }
+    });
+  }
+
+  protected removeAnnouncement(uuid: string) {
+    if (this.instance == null) return;
+
+    let newList: Announcement[] = [];
+    for (let announcement of this.instance.announcements) {
+      if (announcement.announcementId !== uuid) newList.push(announcement);
+    }
+
+    this.instance.announcements = newList;
+    this.client.updateCachedInstance(this.instance);
+  }
+
+  protected readonly faBullhorn = faBullhorn;
+  protected readonly faPencil = faPencil;
+  protected readonly faPaperPlane = faPaperPlane;
+}

--- a/src/app/pages/mod-panel/mod-panel.component.ts
+++ b/src/app/pages/mod-panel/mod-panel.component.ts
@@ -13,7 +13,7 @@ import { DividerComponent } from "../../components/ui/divider.component";
 import { FormControl, FormGroup } from '@angular/forms';
 import { AnnouncementComponent } from "../../components/items/announcement.component";
 import { Announcement } from '../../api/types/announcement';
-import { faBullhorn, faPaperPlane, faPencil, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faBullhorn, faPaperPlane, faPencil, faSignOutAlt, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { TextboxComponent } from "../../components/ui/form/textbox.component";
 import { TextAreaComponent } from "../../components/ui/form/textarea.component";
 import { ButtonComponent } from "../../components/ui/form/button.component";
@@ -22,6 +22,7 @@ import { RouterLink } from "@angular/router";
 import { TwoPaneLayoutComponent } from "../../components/ui/layouts/two-pane-layout.component";
 import { ContainerComponent } from "../../components/ui/container.component";
 import { PaneTitleComponent } from "../../components/ui/text/pane-title.component";
+import { ConfirmationDialogComponent } from "../../components/ui/confirmation-dialog.component";
 
 @Component({
     selector: 'app-mod-panel',
@@ -35,7 +36,8 @@ import { PaneTitleComponent } from "../../components/ui/text/pane-title.componen
     RouterLink,
     TwoPaneLayoutComponent,
     ContainerComponent,
-    PaneTitleComponent
+    PaneTitleComponent,
+    ConfirmationDialogComponent
 ],
     templateUrl: './mod-panel.component.html'
 })
@@ -60,6 +62,7 @@ export class ModPanelComponent {
     text: new FormControl(),
   });
   protected isAnnouncementComplete: boolean = false;
+  protected showAnnouncementPostDialog: boolean = false;
 
   protected grafanaSafeUrl: SafeUrl | undefined;
 
@@ -134,9 +137,14 @@ export class ModPanelComponent {
     };
   }
 
+  protected toggleAnnouncementPostDialog(visibility: boolean) {
+    this.showAnnouncementPostDialog = visibility;
+  }
+
   protected postAnnouncement() {
     if (this.instance == null || !this.isAnnouncementComplete) return;
-    
+    this.toggleAnnouncementPostDialog(false);
+
     this.client.postAnnouncement(this.previewAnnouncement).subscribe({
       error: error => {
         const apiError: RefreshApiError | undefined = error.error?.error;
@@ -170,4 +178,5 @@ export class ModPanelComponent {
   protected readonly faPencil = faPencil;
   protected readonly faPaperPlane = faPaperPlane;
   protected readonly faTrash = faTrash;
+  protected readonly faSignOutAlt = faSignOutAlt;
 }

--- a/src/app/pages/mod-panel/mod-panel.component.ts
+++ b/src/app/pages/mod-panel/mod-panel.component.ts
@@ -46,6 +46,8 @@ export class ModPanelComponent {
 
   protected instance: Instance | undefined;
   protected instanceDownloadFailed: boolean = false;
+  protected announcements: Announcement[] | undefined;
+  protected announcementsDownloadFailed: boolean = false;
   protected blockedAssetFlags: String = "None";
   protected blockedAssetFlagsForTrustedUsers: String = "None";
 
@@ -104,6 +106,17 @@ export class ModPanelComponent {
               this.statistics = response;
             }
           });
+
+          client.getAllAnnouncements().subscribe({
+            error: error => {
+              this.announcementsDownloadFailed = true;
+              const apiError: RefreshApiError | undefined = error.error?.error;
+              this.banner.error("Failed to retrieve announcements", apiError == null ? error.message : apiError.message);
+            },
+            next: response => {
+              this.announcements = response;
+            }
+          });
         }
       }
     });
@@ -142,7 +155,7 @@ export class ModPanelComponent {
   }
 
   protected postAnnouncement() {
-    if (this.instance == null || !this.isAnnouncementComplete) return;
+    if (!this.isAnnouncementComplete) return;
     this.toggleAnnouncementPostDialog(false);
 
     this.client.postAnnouncement(this.previewAnnouncement).subscribe({
@@ -152,23 +165,24 @@ export class ModPanelComponent {
       },
       next: response => {
         this.resetAnnouncementInputs();
-        this.instance!.announcements.push(response);
+        let newList: Announcement[] = [];
+        newList.push(response);
+
+        if (!this.announcements) this.announcements = newList
+        else this.announcements = newList.concat(this.announcements);
       }
     });
   }
 
   protected removeAnnouncement(uuid: string) {
-    if (this.instance == null) return;
+    if (this.announcements == null) return;
 
     let newList: Announcement[] = [];
-    for (let announcement of this.instance.announcements) {
+    for (let announcement of this.announcements) {
       if (announcement.announcementId !== uuid) newList.push(announcement);
     }
 
-    this.instance.announcements = newList;
-    // Even if we update the instance cached by ClientService, the instance responses usually have a cache control header
-    // set to 1 hour, so simply refreshing the website will get us the outdated instance response again.
-    // Therefore, TODO: implement and use a separate endpoint for retreiving announcement lists.
+    this.announcements = newList;
   }
 
   protected readonly faBullhorn = faBullhorn;

--- a/src/app/pages/mod-panel/mod-panel.component.ts
+++ b/src/app/pages/mod-panel/mod-panel.component.ts
@@ -58,6 +58,7 @@ export class ModPanelComponent {
     announcementId: "",
     title: "",
     text: "",
+    createdAt: undefined,
   };
   protected announcementForm = new FormGroup({
     title: new FormControl(),
@@ -147,6 +148,7 @@ export class ModPanelComponent {
       announcementId: "",
       title: "",
       text: "",
+      createdAt: undefined,
     };
   }
 

--- a/src/app/pages/mod-panel/mod-panel.component.ts
+++ b/src/app/pages/mod-panel/mod-panel.component.ts
@@ -13,7 +13,7 @@ import { DividerComponent } from "../../components/ui/divider.component";
 import { FormControl, FormGroup } from '@angular/forms';
 import { AnnouncementComponent } from "../../components/items/announcement.component";
 import { Announcement } from '../../api/types/announcement';
-import { faBullhorn, faPaperPlane, faPencil } from '@fortawesome/free-solid-svg-icons';
+import { faBullhorn, faPaperPlane, faPencil, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { TextboxComponent } from "../../components/ui/form/textbox.component";
 import { TextAreaComponent } from "../../components/ui/form/textarea.component";
 import { ButtonComponent } from "../../components/ui/form/button.component";
@@ -85,12 +85,9 @@ export class ModPanelComponent {
 
               // initialize sanitized URL
               let originalUrl = this.instance?.grafanaDashboardUrl;
-              if (originalUrl == null || originalUrl.length <= 0) {
-                originalUrl = "";
+              if (originalUrl != null && originalUrl.length > 0) {
+                this.grafanaSafeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(originalUrl);
               }
-
-              this.grafanaSafeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(originalUrl);
-              console.log("safe grafana url: " + this.grafanaSafeUrl);
             }
           });
       
@@ -148,8 +145,11 @@ export class ModPanelComponent {
       next: response => {
         this.resetAnnouncementInputs();
 
-        // currently the server doesn't sort the announcements, so this is fine
+        // currently the server doesn't sort the announcements, so this is fine.
+        // also, TODO: implement and use a separate endpoint for retreiving announcement lists,
+        // because the instance responses usually have a cache-control header
         this.instance!.announcements.push(response);
+        this.client.updateCachedInstance(this.instance!);
       }
     });
   }
@@ -169,4 +169,5 @@ export class ModPanelComponent {
   protected readonly faBullhorn = faBullhorn;
   protected readonly faPencil = faPencil;
   protected readonly faPaperPlane = faPaperPlane;
+  protected readonly faTrash = faTrash;
 }

--- a/src/app/pages/mod-panel/mod-panel.component.ts
+++ b/src/app/pages/mod-panel/mod-panel.component.ts
@@ -152,12 +152,7 @@ export class ModPanelComponent {
       },
       next: response => {
         this.resetAnnouncementInputs();
-
-        // currently the server doesn't sort the announcements, so this is fine.
-        // also, TODO: implement and use a separate endpoint for retreiving announcement lists,
-        // because the instance responses usually have a cache-control header
         this.instance!.announcements.push(response);
-        this.client.updateCachedInstance(this.instance!);
       }
     });
   }
@@ -171,7 +166,9 @@ export class ModPanelComponent {
     }
 
     this.instance.announcements = newList;
-    this.client.updateCachedInstance(this.instance);
+    // Even if we update the instance cached by ClientService, the instance responses usually have a cache control header
+    // set to 1 hour, so simply refreshing the website will get us the outdated instance response again.
+    // Therefore, TODO: implement and use a separate endpoint for retreiving announcement lists.
   }
 
   protected readonly faBullhorn = faBullhorn;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,7 +26,7 @@ const defaultColors = {
   "dark-green": "#4a9e27ff",
   "light-blue": "#2d92e5ff",
   "blue": "#2D43E5",
-  "yellow": "#F2AA00",
+  "yellow": "#DB9901",
   "orange": "#f8640eff",
   "dark-pink": "#f145a4ff",
   "pink": "#ff68f4",


### PR DESCRIPTION
This recreates a part of the old website's moderation panel for the beta website. It's accessible through the header, shows a few moderation-related stats, and allows posting announcements. This PR also slightly improves the layout of the instance info page (to make it look similar to the stats display on the mod panel), and announcements can now generally be deleted by mods.